### PR TITLE
Redraw, Theme Changes, and Stack Counts

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -16,6 +16,7 @@ Use `!tak @opponent` to start a new game. You can use `--option` to specify any 
   - `undo` to step back one move in the game. Only available until the next player makes their move.
   - `history` to see a list of finished games and their IDs. Use a page number to see older games.
   - `link` to get a link for the current game in ptn.ninja.
+  - `redraw` to re-send the last board of the current game.
   - `end` to end the current game.
   - `delete` to delete the current game channel and clean up.
   - `help` to see this message.

--- a/bot.js
+++ b/bot.js
@@ -297,13 +297,6 @@ function getHistoryFromFile(page) {
     }
 }
 
-async function deleteLastGameMessage(msg) {
-    let messages = await getGameMessages(msg);
-    if (messages.array().length > 0) {
-        messages.first().delete();
-    }
-}
-
 async function setDeleteTimer(msg) {
     await sendMessage(msg, 'This channel will self destruct in approximately 24 hours unless a new game is started.');
     let timerId = setTimeout(handleDelete, 86400000, msg);
@@ -330,15 +323,6 @@ async function clearReminderTimer(msg) {
         clearInterval(timerId);
         reminderTimers.splice(reminderTimers.indexOf(timerId), 1);
     }
-}
-
-
-
-// Getter functions for reading from Discord
-
-async function getGameMessages(msg) {
-    let messages = await msg.channel.messages.fetch();
-    return messages.filter(m => m.author.id === client.user.id).filter(m => m.attachments.array().length);
 }
 
 
@@ -641,7 +625,6 @@ async function handleUndo(msg) {
         return sendMessage(msg, 'You cannot undo a move that is not your own.');
     }
 
-    await deleteLastGameMessage(msg);
     deleteLastTurn(msg, gameData);
     gameData = getGameData(msg);
     const canvas = drawBoard(gameData, getTheme(msg));
@@ -770,7 +753,6 @@ async function handleTheme(msg, theme) {
             } else {
                 // Re-create current board
                 const gameData = getGameData(msg);
-                await deleteLastGameMessage(msg);
                 const canvas = drawBoard(gameData, theme);
                 const message = getTurnMessage(gameData, canvas);
                 return sendPngToDiscord(msg, canvas, message);

--- a/bot.js
+++ b/bot.js
@@ -710,7 +710,7 @@ function handleHistory(msg, page='1') {
     try {
         let historyData = getHistoryFromFile(parseInt(page));
         if (historyData) {
-            return sendMessage(msg, historyData);
+            return sendMessage(msg, '```\n' + historyData + '\n```');
         } else {
             return sendMessage(msg, 'Not a valid page number');
         }

--- a/bot.js
+++ b/bot.js
@@ -653,6 +653,16 @@ async function handleLink(msg, gameId) {
     }
 }
 
+async function handleRedraw(msg) {
+    if (!isGameOngoing(msg)) {
+        return sendMessage(msg, 'I couldn\'t find an ongoing game in this channel.');
+    }
+    const gameData = getGameData(msg);
+    const canvas = drawBoard(gameData, getTheme(msg));
+    const message = getTurnMessage(gameData, canvas);
+    return sendPngToDiscord(msg, canvas, message);
+}
+
 async function handleRematch(msg) {
     const gameData = getGameData(msg);
     if (!gameData) {
@@ -751,11 +761,7 @@ async function handleTheme(msg, theme) {
             if (!isGameOngoing(msg)) {
                 return sendMessage(msg, 'Theme set.');
             } else {
-                // Re-create current board
-                const gameData = getGameData(msg);
-                const canvas = drawBoard(gameData, theme);
-                const message = getTurnMessage(gameData, canvas);
-                return sendPngToDiscord(msg, canvas, message);
+                handleRedraw(msg);
             }
         }
     } else {
@@ -818,6 +824,8 @@ client.on('message', msg => {
                 return handleUndo(msg);
             case 'link':
                 return handleLink(msg, args[1]);
+            case 'redraw':
+                return handleRedraw(msg);
             case 'rematch':
                 return handleRematch(msg);
             case 'history':


### PR DESCRIPTION
- New command `redraw` to resend the last board
- Don't try to delete previous takbot message on undo or theme change
- New feature: Stack Counts
  - Show only the first 10 immovable pieces in a stack
- Theme changes
  - Add Atlas theme
  - Add Backlit theme
  - Add BubbleTron theme
  - Add Luna theme
  - Remove Festive theme
  - Update Aether, Stealth, Terra, Zen themes
  - Adjust border widths