### PR TITLE
Adds /draw command and refines timers

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -20,6 +20,7 @@ Use `/tak @opponent` to start a new game. You can specify any of the following:
 **Standalone commands:**
 
 - `delete` to delete the current game channel
+- `draw` to offer a draw, or accept your opponent's draw offer
 - `end` to cancel the current game
 - `history` to see a list of finished games and their IDs. Specify a page number to see older games
 - `info` to display information about the current game

--- a/commands/draw.js
+++ b/commands/draw.js
@@ -1,0 +1,99 @@
+const { SlashCommandBuilder } = require("discord.js");
+const {
+  addToHistoryFile,
+  cleanupFiles,
+  clearInactiveTimer,
+  getGameData,
+  getLink,
+  isGameOngoing,
+  isPlayer,
+  pinMessage,
+  renameChannel,
+  saveGameData,
+  sendMessage,
+  setDeleteTimer,
+} = require("../util");
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("draw")
+    .setDescription("Offer a draw, or accept your opponent's draw offer."),
+  async execute(interaction) {
+    let gameData = getGameData(interaction);
+
+    if (!gameData) {
+      return sendMessage(interaction, "This isn't a game channel.", true);
+    }
+
+    if (!isGameOngoing(interaction)) {
+      return sendMessage(
+        interaction,
+        "There is no ongoing game in this channel.",
+        true
+      );
+    }
+
+    if (!isPlayer(interaction.member.id, gameData)) {
+      return sendMessage(interaction, "You are not an active player.", true);
+    }
+
+    const opponentId =
+      interaction.member.id === gameData.player1Id
+        ? gameData.player2Id
+        : gameData.player1Id;
+
+    // An offer is only valid if the board hasn't changed since it was made.
+    const offer = gameData.drawOffer;
+    const offerIsValid = offer && offer.tps === gameData.tps;
+
+    // When one player controls both seats, there's no one to accept the offer,
+    // so the draw takes effect immediately.
+    const isSelfPlay = gameData.player1Id === gameData.player2Id;
+
+    if (!isSelfPlay && offerIsValid && offer.playerId === interaction.member.id) {
+      return sendMessage(
+        interaction,
+        "You've already offered a draw. Waiting for your opponent to accept with `/draw`.",
+        true
+      );
+    }
+
+    if (isSelfPlay || (offerIsValid && offer.playerId === opponentId)) {
+      // Offer is accepted (or self-play): end the game as a draw.
+      const result = "1/2-1/2";
+      cleanupFiles(interaction.channel.id);
+      if (gameData.gameId) {
+        addToHistoryFile({
+          gameId: gameData.gameId,
+          player1: gameData.player1,
+          player2: gameData.player2,
+          komi: gameData.komi,
+          opening: gameData.opening,
+          result: result,
+        });
+      }
+      const finalMessage = await sendMessage(
+        interaction,
+        `Draw accepted! Game Ended ${result}\nHere's a link to the completed game:\nID: [${
+          gameData.gameId
+        }](${getLink(gameData.gameId)})`
+      );
+      clearInactiveTimer(interaction);
+      setDeleteTimer(interaction);
+      await pinMessage(finalMessage);
+      return renameChannel(interaction, false);
+    }
+
+    // No valid offer: record this player's draw offer.
+    gameData.drawOffer = {
+      playerId: interaction.member.id,
+      tps: gameData.tps,
+    };
+    saveGameData(interaction, { gameData });
+
+    return sendMessage(
+      interaction,
+      `<@${interaction.member.id}> offers a draw. <@${opponentId}>, use \`/draw\` to accept.`
+    );
+  },
+};

--- a/commands/resign.js
+++ b/commands/resign.js
@@ -55,9 +55,9 @@ module.exports = {
         gameData.gameId
       }](${getLink(gameData.gameId)})`
     );
-    await pinMessage(finalMessage);
     clearInactiveTimer(interaction);
     setDeleteTimer(interaction);
+    await pinMessage(finalMessage);
     return renameChannel(interaction, false);
   },
 };

--- a/commands/undo.js
+++ b/commands/undo.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require("discord.js");
 const {
+  clearDrawOffer,
   clearInactiveTimer,
   deleteLastTurn,
   drawBoard,
@@ -53,6 +54,7 @@ module.exports = {
     }
 
     deleteLastTurn(interaction, gameData);
+    clearDrawOffer(interaction);
     gameData = getGameData(interaction);
     const canvas = drawBoard(gameData, getTheme(interaction));
     const message = "Undo complete!\n" + getTurnMessage(gameData, canvas);

--- a/util.js
+++ b/util.js
@@ -266,6 +266,8 @@ module.exports = {
     let nextPlayer = gameData.player1Id;
     if (gameData.turnMarker === "1") nextPlayer = gameData.player2Id;
 
+    module.exports.clearDrawOffer(msg);
+
     if (!canvas.isGameEnd) {
       // Game is still in progress
       module.exports.saveGameData(msg, { tps: canvas.id, ply });
@@ -396,6 +398,28 @@ module.exports = {
     try {
       fs.mkdirSync(tpsDir, { recursive: true });
       fs.writeFileSync(path.join(tpsDir, filename + ".tps"), tps);
+    } catch (err) {
+      console.error(err);
+    }
+  },
+
+  clearDrawOffer(msg) {
+    const metaPath = path.join(
+      __dirname,
+      "data",
+      msg.channelId || msg.channel.id,
+      "meta",
+      "game.json"
+    );
+    try {
+      if (!fs.existsSync(metaPath)) {
+        return;
+      }
+      const data = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+      if (data.drawOffer) {
+        delete data.drawOffer;
+        fs.writeFileSync(metaPath, JSON.stringify(data));
+      }
     } catch (err) {
       console.error(err);
     }

--- a/util.js
+++ b/util.js
@@ -8,6 +8,11 @@ const { Ply } = require("./TPS-Ninja/src/Ply");
 
 // Constants
 const DELETE_TIMER_MS = 864e5;
+// When the bot restarts and finds an inactive reminder that came due while it
+// was offline, wait this base delay (plus a random stagger) before firing,
+// rather than bursting all overdue reminders the instant we reconnect.
+const REMINDER_STARTUP_GRACE_MS = 6e4; // 1 minute
+const REMINDER_STARTUP_JITTER_MS = 3e5; // up to 5 minutes of stagger
 const INACTIVE_MESSAGES = [
   "It's been a while since your last move. Please take your turn soon, @player.",
   "Ready to jump back in, @player? The game is waiting for your move!",
@@ -97,7 +102,7 @@ function clearTimer(type, channelId, timestamp) {
       timerId = deleteTimers[channelId];
       if (timerId) {
         clearTimeout(timerId);
-        delete deleteTimers[timerId];
+        delete deleteTimers[channelId];
       }
       filePath = path.join(timerDir, `${type}.json`);
       break;
@@ -105,7 +110,7 @@ function clearTimer(type, channelId, timestamp) {
       timerId = inactiveTimers[channelId];
       if (timerId) {
         clearTimeout(timerId);
-        delete inactiveTimers[timerId];
+        delete inactiveTimers[channelId];
       }
       filePath = path.join(timerDir, `${type}.json`);
       break;
@@ -264,9 +269,6 @@ module.exports = {
     if (!canvas.isGameEnd) {
       // Game is still in progress
       module.exports.saveGameData(msg, { tps: canvas.id, ply });
-      if (!msg.channel.name.includes("🆚")) {
-        module.exports.renameChannel(msg, true);
-      }
       const message = module.exports.getTurnMessage(
         gameData,
         canvas,
@@ -781,9 +783,12 @@ module.exports = {
       console.log("Channel not found:", channelId);
       return false;
     }
-    const delay = timestamp * 1e3 - new Date().getTime();
+    let delay = timestamp * 1e3 - new Date().getTime();
     switch (type) {
       case "delete":
+        if (deleteTimers[channelId]) {
+          clearTimeout(deleteTimers[channelId]);
+        }
         deleteTimers[channelId] = setTimeout(
           module.exports.handleDelete,
           delay,
@@ -797,6 +802,21 @@ module.exports = {
         }
         if (!index) {
           index = 0;
+        }
+        if (!interval) {
+          interval = DELETE_TIMER_MS;
+        }
+        if (delay <= 0) {
+          // The scheduled time already passed (e.g. the bot was offline), so
+          // the player is genuinely overdue. Fire soon, after a short
+          // staggered grace delay, rather than bursting all overdue reminders
+          // the instant we reconnect. The normal cadence resumes afterward.
+          delay =
+            REMINDER_STARTUP_GRACE_MS +
+            Math.floor(Math.random() * REMINDER_STARTUP_JITTER_MS);
+        }
+        if (inactiveTimers[channelId]) {
+          clearTimeout(inactiveTimers[channelId]);
         }
         inactiveTimers[channelId] = setTimeout(() => {
           module.exports.sendMessage(


### PR DESCRIPTION
Adds the new `/draw` command, allowing players to offer and accept draw proposals during a game. The command includes logic for:
- Offering a draw to an opponent.
- Accepting an opponent's draw offer, which ends the game.
- Handling draws in self-play scenarios.
- Ensuring draw offers are invalidated if the board state changes.

Also includes several improvements to game timers and state management:
- Addresses issues with spurious inactivity reminders by implementing a graceful, staggered delay for overdue reminders upon bot startup.
- Fixes incorrect timer cancellation logic, ensuring timers are properly cleared and preventing potential memory leaks.
- Ensures new moves and undo actions automatically clear any pending draw offers.
- Prevents mid-game channel renames that occurred during regular moves.
- Updates `TPS-Ninja` to v1.0.43 to fix DBS reserve missing top flat after first move